### PR TITLE
Uno R4 and fix for some Compilers

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=An Arduino-compatible library for the 24-bit ADS1256 analog-to-digital 
 paragraph=It can also work with STM32 (STM32duino) and ESP32 microcontrollers.
 category=Sensors
 url=https://github.com/CuriousScientist0/ADS1256
-architectures=avr, stm32, esp32
+architectures=avr, stm32, esp32, renesas_uno
 includes=ADS1256.h
 depends=

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -97,11 +97,6 @@ class ADS1256
 	
 public:
 
-const byte DRDY_pin;
-const byte RESET_pin;
-const byte SYNC_pin;
-const byte CS_pin;
-
 	//Constructor
 	ADS1256(const byte DRDY_pin, const byte RESET_pin, const byte SYNC_pin, const byte CS_pin, float VREF);
 	


### PR DESCRIPTION
Hi, I checked your library example with an Arduino Uno R4 Wifi and after a small fix it works without any issues. The public const byte class members for the SPI etc. Pins cause a small compiler problem as in the Issue from [mafiou86](https://github.com/mafiou86). The workaround with the initializer list works but I think the public class members are not really necessary because the lib works with the private members anyway after calling the constructor. Deleting them doesn't seem to change the functionality and removes the compiler errors. With this fixes the lib should work on almost all Arduino compatible boards.

