### PR TITLE
Remove DRDY ISR

### DIFF
--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -148,6 +148,9 @@ public:
 	
 private:
 
+// Block until DRDY is low
+void waitForDRDY();
+
 float _VREF; //Value of the reference voltage
 //Pins
 byte _DRDY_pin; //Pin assigned for DRDY


### PR DESCRIPTION
This PR fixes #12 by simply observing DRDY directly rather than relying on an intermediate variable set in an ISR.

I have an alternate branch [`fix-drdy`](https://github.com/BenjaminPelletier/ADS1256/commit/404f34a08476c3deb42b31c958d413edd2ccb066) on my fork that keeps the ISR and tries to prevent DRDY_value from being set true before the falling DRDY signal could possibly indicate actual readiness following the previous operation.  But, it seems unnecessary to worry about the complexity of an ISR since we're blocking on the falling edge any way.

This PR would not be a good idea if DRDY fell and then rose again in less time than the `while` loop took to check again, but this seems unlikely to me (and empirically seems not to be the case).  This PR would also not be a good idea if we wanted to recognize a fall in DRDY prior to starting `waitForDRDY()` even if DRDY had since returned high, but I don't think we want to do this either.

The demo sketch in #12 is fixed by this PR.  However, I am still seeing sporadic bad measurements even after this PR (added #15), though this behavior appears to be identical with that of my `fix-drdy` branch, so I don't think this fix is the cause of that problem.