### PR TITLE
Added continuous single-channel conversion

### DIFF
--- a/examples/ADS1256-Example/ADS1256-Example.ino
+++ b/examples/ADS1256-Example/ADS1256-Example.ino
@@ -235,6 +235,20 @@ void loop()
         Serial.println(voltageValue, 8); //Print the floating point number with 8 digits.
         break;
       //--------------------------------------------------------------------------------------------------------
+      case 'x': // Continuous single channel conversion
+
+      while (Serial.read() != 's') // The conversion is stopped by a character received from the serial port
+      {
+        rawConversion = A.readSingle();                   // Reading the raw value from a previously selected input, passing it to a variable
+        voltageValue = A.convertToVoltage(rawConversion); // Converting the above conversion into a floating point number
+
+        // Printing the results
+        Serial.println(voltageValue, 8); // Print the floating point number with 8 digits.
+      }
+
+      A.stopConversion();
+      break;
+      //--------------------------------------------------------------------------------------------------------
       case 'M': //set MUX
         {
           while (!Serial.available());


### PR DESCRIPTION
Dear @CuriousScientist0 

First, thank you for your fantastic work with this library and the hardware project. It's awesome.

Here, I am contributing my _two cents_ with a new serial console input case that enables continuous conversion on a single channel, similar to "Cycle single-ended inputs" enabled by the input character `'C'`. In this case, after sending `'x'` the ADC will continuously print readings from a single channel, as follows: (Channel A0 shown here)

<img width="721" alt="image" src="https://github.com/user-attachments/assets/f43dc412-ef89-4a02-aec0-0398d0026056">

This allows for convenient printing of serial data, primarily for testing of single events. Here I am using the [Serial Analyzer](https://github.com/curiores/SerialAnalyzer) App from _curiores_ using decimation for visualization of the changes in a potentiometer (yeah I know that decimating defeats the purpose of having 24 bits of resolution but it's just an example 😉 )

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/a41fa72f-f61f-4128-808f-974c2afdc0b6">


This has been tested on an ESP32-S2 WEMOS Mini v1.0, however, I had to use an external USB-UART since I struggled with the native USB port and my serial terminal. 

*Side note:* Based on the issues I described with serial communication, I have been working on additional changes to allow the user to select different serial communication objects (pointer-based) as some boards do not implement easy UART communication, like those that come with an onboard USB-UART converter, like the CP2102N on some ESP32 boards.