### PR TITLE
convertToVoltage optimization

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -38,8 +38,10 @@ ADS1256::ADS1256(const byte DRDY_pin, const byte RESET_pin, const byte SYNC_pin,
 	pinMode(_CS_pin, OUTPUT);
 	
 	_VREF = VREF;
+	_PGA = 1;
+	updateConvertConst();	
 }
-	
+
 
 //Initialization
 void ADS1256::InitializeADC()
@@ -128,6 +130,8 @@ void ADS1256::setPGA(uint8_t pga) //Setting PGA (input voltage range)
 	
 	writeRegister(ADCON_REG, _ADCON);	
 	delay(200);
+
+	updateConvertConst();
 }
 
 uint8_t ADS1256::getPGA() //Reading PGA from the ADCON register
@@ -495,10 +499,7 @@ void ADS1256::sendDirectCommand(uint8_t directCommand)
 
 float ADS1256::convertToVoltage(int32_t rawData) //Converting the 24-bit data into a voltage value
 {
-  float voltage = ((2 * _VREF) / 8388608) * rawData / (pow(2, _PGA)); //8388608 = 2^{23} - 1
-  //REF: p23, Table 16.
-	
-  return(voltage);
+  return _CONVERT_CONST * rawData;
 }
 
 void ADS1256::writeRegister(uint8_t registerAddress, uint8_t registerValueToWrite)
@@ -778,5 +779,8 @@ long ADS1256::cycleDifferential()
 	return _outputValue;
 }
 
-
+void ADS1256::updateConvertConst()
+{
+	_CONVERT_CONST = ((2 * _VREF) / 8388608) / (pow(2, _PGA)); //8388608 = 2^{23} - 1
+}
 

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -147,11 +147,14 @@ public:
 		
 	//Stop AD
 	void stopConversion();
-	
+
 private:
+
+void updateConvertConst();
 
 void waitForDRDY(); // Block until DRDY is low
 
+float _CONVERT_CONST;
 float _VREF; //Value of the reference voltage
 //Pins
 byte _DRDY_pin; //Pin assigned for DRDY

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -150,11 +150,11 @@ public:
 
 private:
 
-void updateConvertConst();
+void updateConvertConst(); // update voltage conversion constant
 
 void waitForDRDY(); // Block until DRDY is low
 
-float _CONVERT_CONST;
+float _CONVERT_CONST; // voltage conversion constant
 float _VREF; //Value of the reference voltage
 //Pins
 byte _DRDY_pin; //Pin assigned for DRDY


### PR DESCRIPTION
Thank you for the library, I'm not sure if you accept PRs, I'm sending optimization for case you do. The convertToVoltage() is doing unnecessary calculations for each sample. When I run benchmark (B) in original example sketch doing just `A.readSingleContinuous();`
with maximum speed setting (F0), result is:
`DRATE is selected as: 240
DRATE is set to 240
Total conversion time for 150k samples: 3351574 us
Sampling rate: 44755.091 SPS
`
After change to `A.convertToVoltage(A.readSingleContinuous());` sampling rate drops to 30002.346 SPS.
After pre-caching the conversion constant the sample rate is 42461.739 SPS.
Tested with ESP32-S3
