### PR TITLE
cycle, finishCycle

### DIFF
--- a/examples/ADS1256-Example/ADS1256-Example.ino
+++ b/examples/ADS1256-Example/ADS1256-Example.ino
@@ -167,7 +167,7 @@ void loop()
           }
           Serial.println();//Printing a linebreak - this will put the next 8 conversions in a new line
         }
-        A.stopConversion();
+        A.finishCycle(); // read and ignore last conversion
         break;
       //--------------------------------------------------------------------------------------------------------
       case 'D': //Cycle differential inputs (A0+A1, A2+A3, A4+A5, A6+A7)
@@ -191,7 +191,33 @@ void loop()
           }
           Serial.println();//Printing a linebreak - this will put the next 4 conversions in a new line
         }
-        A.stopConversion();
+        A.finishCycle(); // read and ignore last conversion
+        break;
+      //--------------------------------------------------------------------------------------------------------
+      case 'V': //Cycle various inputs (A0+GND, A1+GND, A2+A3, A4+A5)
+        A.setMUX(SING_0);
+        while (Serial.read() != 's') //The conversion is stopped by a character received from the serial port
+        {
+          float channels[4]; //Buffer that holds 4 conversions
+          
+          channels[0] = A.convertToVoltage(A.cycle(SING_1)); //store the previous conversion result (SING_0) in the buffer and start converting SING_1
+          channels[1] = A.convertToVoltage(A.cycle(DIFF_2_3)); //store the previous conversion result (SING_1) in the buffer and start converting DIFF_2_3
+          channels[2] = A.convertToVoltage(A.cycle(DIFF_4_5)); //store the previous conversion result (DIFF_2_3) in the buffer and start converting DIFF_4_5
+          channels[3] = A.convertToVoltage(A.cycle(SING_0)); //store the previous conversion result (DIFF_4_5) in the buffer and start converting SING_0
+
+          //After the 4 conversions are in the buffer, the contents are printed on the serial terminal
+          for (int i = 0; i < 4; i++)
+          {
+            Serial.print(channels[i], 4);//print the converted differential results from the buffer
+
+            if (i < 3) //Only printing tab between the first 3 conversions
+            {
+              Serial.print("\t"); //tab separator to separate the 4 conversions shown in the same line
+            }
+          }
+          Serial.println();//Printing a linebreak - this will put the next 4 conversions in a new line
+        }
+        A.finishCycle(); // read and ignore last conversion
         break;
       //--------------------------------------------------------------------------------------------------------
       case 'B': //Speed test

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -142,17 +142,24 @@ public:
 	//Cycling through the differential inputs
 	long cycleDifferential(); //Ax + Ay
 		
+	//Cycles through the inputs based on the nextSource value
+	long cycle(byte nextSource); 
+
+	// read the last conversion
+	long finishCycle();
+
 	//Converts the reading into a voltage value
 	float convertToVoltage(int32_t rawData);
 		
 	//Stop AD
 	void stopConversion();
-	
+
 private:
 
 void waitForLowDRDY(); // Block until DRDY is low
 void waitForHighDRDY(); // Block until DRDY is high
 void updateMUX(uint8_t muxValue);
+long rdata(); //Read the converted data
 
 void updateConversionParameter(); //Refresh the conversion parameter based on the PGA
 


### PR DESCRIPTION
I need to cycle different inputs than existing **cycle...()** methods offers, so I've added the **cycle(byte nextSource)** method to allow flexible cycling.
I've also added the **finishCycle()** method to read last value and end the cycle. I've used it in the example project after cycle commands, because **stopConversion()** sends unnecessary SDATAC command so I've found it more appropriate even when in example project last value is not used.
Added the 'V' command to example to show the **cycle()** method usage. I hope you'll find it useful.