### PR TITLE
reset by SCLK reset pattern while initializing

### DIFF
--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -156,6 +156,9 @@ void updateMUX(uint8_t muxValue);
 
 void updateConversionParameter(); //Refresh the conversion parameter based on the PGA
 
+void resetByClk(); // send SCLK reset pattern
+
+
 float _VREF = 0; //Value of the reference voltage
 float conversionParameter = 0; //PGA-dependent multiplier
 //Pins


### PR DESCRIPTION
I've got the board without RESET pin so ADS is not reset when I invoke software reset or press the RST button on the controller board. If the ADC gets into wrong state there is no way to fix it except unplugging whole device. (It happens to me sometimes when tuning on/off some circuits). I've implemented the alternative reset procedure to initialization, could be useful for others