### PR TITLE
Add support for reading single continous from ISR

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -94,6 +94,11 @@ void ADS1256::InitializeADC()
   _isAcquisitionRunning = false; //MCU will be waiting to start a continuous acquisition
 }
 
+void ADS1256::setInterruptFunction(void (*userSuppliedFunction)(void)) //Bind user supplied function to a data ready event
+{
+	attachInterrupt(digitalPinToInterrupt(_DRDY_pin), userSuppliedFunction, FALLING);
+}
+
 void ADS1256::waitForLowDRDY()
 {		    
     while (digitalRead(_DRDY_pin) == HIGH) {} 
@@ -551,8 +556,8 @@ long ADS1256::readSingle() //Reading a single value ONCE using the RDATA command
 	return(_outputValue);
 }
 
-long ADS1256::readSingleContinuous() //Reads the recently selected input channel using RDATAC
-{		
+void ADS1256::startSingleContinuousConversion() //Sending RDATAC to start the continuous conversion
+{
 	if(_isAcquisitionRunning == false)
 	{
 	  _isAcquisitionRunning = true;
@@ -562,10 +567,13 @@ long ADS1256::readSingleContinuous() //Reads the recently selected input channel
 	  _spi->transfer(0b00000011);  //Issue RDATAC (0000 0011) 
 	  delayMicroseconds(7); //Wait t6 time (~6.51 us) REF: P34, FIG:30.	  
 	}
-	else
-	{
-		waitForLowDRDY();
-	}	
+}
+
+long ADS1256::readSingleContinuous() //Reads the recently selected input channel using RDATAC
+{
+	startSingleContinuousConversion();
+
+	waitForLowDRDY();
 	
 	_outputBuffer[0] = _spi->transfer(0); // MSB 
 	_outputBuffer[1] = _spi->transfer(0); // Mid-byte
@@ -576,6 +584,18 @@ long ADS1256::readSingleContinuous() //Reads the recently selected input channel
 	
 	waitForHighDRDY();
 	
+	return _outputValue;
+}
+
+long ADS1256::readSingleContinuousImmediately() //Reads the recently selected input channel using RDATAC without waiting for correct state of DRDY pin
+{
+	_outputBuffer[0] = _spi->transfer(0); // MSB
+	_outputBuffer[1] = _spi->transfer(0); // Mid-byte
+	_outputBuffer[2] = _spi->transfer(0); // LSB
+
+	_outputValue = ((long)_outputBuffer[0]<<16) | ((long)_outputBuffer[1]<<8) | (_outputBuffer[2]);
+	_outputValue = convertSigned24BitToLong(_outputValue);
+
 	return _outputValue;
 }
 

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -108,6 +108,9 @@ static constexpr int8_t PIN_UNUSED = -1;
 	//Initializing function
 	void InitializeADC();	
 	//ADS1256(int drate, int pga, int byteOrder, bool bufen);
+
+	//Bind user supplied function to a data ready event
+	void setInterruptFunction(void (*userSuppliedFunction)(void));
 	
 	//Read a register
 	long readRegister(uint8_t registerAddress);
@@ -135,9 +138,15 @@ static constexpr int8_t PIN_UNUSED = -1;
 
 	//Get a single conversion
 	long readSingle();
+
+	//Start AD to read the recently selected input channel
+	void startSingleContinuousConversion();
 	
 	//Single input continuous reading
 	long readSingleContinuous();
+
+	//Single input continuous reading without checking for data availability
+	long readSingleContinuousImmediately();
 	
 	//Cycling through the single-ended inputs
 	long cycleSingle(); //Ax + COM


### PR DESCRIPTION
Hi! First, thank you very much for the library. And for the documentation provided!

I used the library in a project with data read from several sensors, including one ADS1256. The sensors took some time to read, and thus with high sampling rates, ADS1256 didn't get the chance (time) to read its value before it was overwritten (by the next high-frequency ADS1256 measurement).

In general — reading values from ADS1256 in an interrupt, and buffering them (storing temporarily), allows to use the library alongside other, slower to execute, code.
The approach was succinctly [explained by dr Bonet over on Arduino Stack Exchange](https://arduino.stackexchange.com/a/102068/130900).

This pull request uses interrupts differently than the way they have been used previously in the library (54c63e5fc0a7a85678930d3dcdb010ea32fd171e).
It does not impact the existing `read___()` and `cycle___()` methods*.
Here, data from ADS1256 is read in the interrupt.

To achieve it, I've added:
- "Stripped down" version of `readSingleContinuous()` — `readSingleContinuousImmediately()`.
This method does not wait for the desired state (LOW/HIGH) of DRDY signal.
I've considered also `readSingleContinuousFromISR()` to align with ESP32's FreeRTOS naming convention, but decided it may imply too much.
- Helper method for attaching the interrupt `setInterruptFunction()`.
I've decided to include it in the library, because the PIN number of `DRDY` and signal indicating ready data (`FALLING`) are both known to the library, and constant.
- *I've extracted the acquisition initializing code to a separate `startSingleContinousConversion()` method, to be used: manually when using this new interrupt-based approach, and called from within `readSingleContinuous()` instead of the code being inline. `readSingleContinuous()` stays backwards compatible.

I tried to keep the library's coding style and conventions.

I believe the implementation is specific to each project, so I didn't add an example code use case.
- One option (most probably the preferred one) is to use a ring buffer as [explained by dr Bonet](https://arduino.stackexchange.com/a/102068/130900).
	```c
	void ARDUINO_ISR_ATTR ADS1256DataReadyCallback()
	{
		ads1256_ring_buffer.push(ads1256->readSingleContinuousImmediately());
	}

	// Inside the main loop:
	while (!ads1256_ring_buffer.empty()) {
		process_ads1256_data(ads1256_ring_buffer.pop());
	}
	```
- Since my project is based on FreeRTOS, I've used a FreeRTOS queue with good performance (30 kHz ADS1256 alongside 800 Hz built-in ADS, 800 Hz first BMI160, and 200 Hz second BMI160). I don't have experience with ring buffers, so although my simple implementation worked, I was afraid of the possible pitfalls, and went with predesigned queue as a safer choice. The flow could be as follows:
	```c
	void ARDUINO_ISR_ATTR ADS1256DataReadyCallback()
	{
		readout = ads1256->readSingleContinuousImmediately();

		xQueueSendFromISR(readoutsQueue, &readout, NULL);
	}

	void setup() {
		ads1256 = new ADS1256(<<settings>>);

		ads1256->InitializeADC();

		ads1256->setMUX(<<value>>);
		ads1256->setPGA(<<value>>);
		ads1256->setDRATE(<<value>>);

		ads1256->startSingleContinousConversion();

		ads1256->setInterruptFunction(ADS1256DataReadyCallback);
	}

	void loop() {
		// read other sensors

		while (xQueueReceive(readoutsQueue, &readoutTemp, 0) == pdPASS)
		{
			processADS1256Data(readoutTemp);
		}
	}
	```
