### PR TITLE
refactor(moderate): fix readRegister return type from long to uint8_t

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -505,7 +505,7 @@ void ADS1256::writeRegister(uint8_t registerAddress, uint8_t registerValueToWrit
   
 }
 
-long ADS1256::readRegister(uint8_t registerAddress) //Reading a register
+uint8_t ADS1256::readRegister(uint8_t registerAddress) //Reading a register
 {
    waitForLowDRDY();
 	
@@ -514,7 +514,7 @@ long ADS1256::readRegister(uint8_t registerAddress) //Reading a register
 
   CS_LOW(); //CS must stay LOW during the entire sequence [Ref: P34, T24]
 
-  _spi->transfer(0x10 | registerAddress); //0x10 = 0001000 = RREG - OR together the two numbers (command + address)
+  _spi->transfer(RREG | registerAddress); //RREG command OR'd with register address
 
   _spi->transfer(0x00); //2nd (empty) command byte
 

--- a/src/ADS1256.h
+++ b/src/ADS1256.h
@@ -110,7 +110,7 @@ static constexpr int8_t PIN_UNUSED = -1;
 	//ADS1256(int drate, int pga, int byteOrder, bool bufen);
 	
 	//Read a register
-	long readRegister(uint8_t registerAddress);
+	uint8_t readRegister(uint8_t registerAddress);
 	
 	//Write a register
 	void writeRegister(uint8_t registerAddress, uint8_t registerValueToWrite);	


### PR DESCRIPTION
- Return type now matches actual register size (8-bit)
- Eliminates unnecessary type promotion from uint8_t to long
- Also replaced magic number 0x10 with RREG constant
- API now correctly reflects that registers are 8-bit values