### PR TITLE
perf(moderate): replace pow() with bit shift in updateConversionParam…

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -738,8 +738,9 @@ long ADS1256::cycleDifferential()
 
 void ADS1256::updateConversionParameter()
 {
-	conversionParameter = ((2.0 * _VREF) / 8388608.0) / (pow(2, _PGA)); //Calculate the "bit to Volts" multiplier	
-	//8388608 = 2^{23} - 1, REF: p23, Table 16.
+	// 8388608 = 2^23 (full scale for 24-bit signed ADC), REF: p23, Table 16
+	// Use bit shift instead of pow() for efficiency
+	conversionParameter = ((2.0 * _VREF) / 8388608.0) / (float)(1 << _PGA);
 }
 
 void ADS1256::updateMUX(uint8_t muxValue)


### PR DESCRIPTION
…eter

- Replace pow(2, _PGA) with (1 << _PGA) for integer power of 2
- Avoids heavy floating-point pow() call from math library
- Fixed incorrect comment: 8388608 = 2^23, not 2^23-1
- Results in smaller code size and faster execution