### PR TITLE
fix(critical): guard stopConversion against ending unopened SPI trans…

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -108,8 +108,12 @@ void ADS1256::waitForHighDRDY()
 
 void ADS1256::stopConversion() //Sending SDATAC to stop the continuous conversion
 {	
+	if (!_isAcquisitionRunning) {
+		return; //Nothing to stop, avoid ending a transaction that was never started
+	}
+	
 	waitForLowDRDY(); //SDATAC should be called after DRDY goes LOW (p35. Figure 33)
-	_spi->transfer(0b00001111); //Send SDATAC to the ADC	
+	_spi->transfer(SDATAC); //Send SDATAC to the ADC	
 	CS_HIGH(); //We finished the command sequence, so we switch it back to HIGH
 	_spi->endTransaction();
 	


### PR DESCRIPTION
…action

- Check _isAcquisitionRunning before attempting to stop
- Return early if no acquisition is running
- Prevents calling endTransaction() without matching beginTransaction()
- Also replaced magic number 0b00001111 with SDATAC constant