### PR TITLE
refactor(moderate): replace magic numbers with defined constants

### DIFF
--- a/src/ADS1256.cpp
+++ b/src/ADS1256.cpp
@@ -109,7 +109,7 @@ void ADS1256::waitForHighDRDY()
 void ADS1256::stopConversion() //Sending SDATAC to stop the continuous conversion
 {	
 	waitForLowDRDY(); //SDATAC should be called after DRDY goes LOW (p35. Figure 33)
-	_spi->transfer(0b00001111); //Send SDATAC to the ADC	
+	_spi->transfer(SDATAC); //Send SDATAC to the ADC	
 	CS_HIGH(); //We finished the command sequence, so we switch it back to HIGH
 	_spi->endTransaction();
 	
@@ -534,7 +534,7 @@ long ADS1256::readSingle() //Reading a single value ONCE using the RDATA command
 	_spi->beginTransaction(SPISettings(1920000, MSBFIRST, SPI_MODE1));
 	CS_LOW(); //REF: P34: "CS must stay low during the entire command sequence"  
 	waitForLowDRDY();
-	_spi->transfer(0b00000001); //Issue RDATA (0000 0001) command
+	_spi->transfer(RDATA); //Issue RDATA command
 	delayMicroseconds(7); //Wait t6 time (~6.51 us) REF: P34, FIG:30.
 
 	_outputBuffer[0] = _spi->transfer(0); // MSB
@@ -559,7 +559,7 @@ long ADS1256::readSingleContinuous() //Reads the recently selected input channel
 	  _spi->beginTransaction(SPISettings(1920000, MSBFIRST, SPI_MODE1));
 	  CS_LOW(); //REF: P34: "CS must stay low during the entire command sequence"	  
 	  waitForLowDRDY();
-	  _spi->transfer(0b00000011);  //Issue RDATAC (0000 0011) 
+	  _spi->transfer(RDATAC);  //Issue RDATAC command 
 	  delayMicroseconds(7); //Wait t6 time (~6.51 us) REF: P34, FIG:30.	  
 	}
 	else
@@ -638,13 +638,12 @@ long ADS1256::cycleSingle()
           break;
       }
       //Step 2.
-      _spi->transfer(0b11111100); //SYNC
+      _spi->transfer(SYNC); //SYNC command
       delayMicroseconds(4); //t11 delay 24*tau = 3.125 us //delay should be larger, so we delay by 4 us
-      _spi->transfer(0b11111111); //WAKEUP
+      _spi->transfer(WAKEUP); //WAKEUP command
 
       //Step 3.
-      //Issue RDATA (0000 0001) command
-      _spi->transfer(0b00000001);
+      _spi->transfer(RDATA); //Issue RDATA command
       delayMicroseconds(7); //Wait t6 time (~6.51 us) REF: P34, FIG:30.
 
 	  _outputBuffer[0] = _spi->transfer(0x0F); // MSB 
@@ -710,12 +709,12 @@ long ADS1256::cycleDifferential()
           break;
       }
 
-      _spi->transfer(0b11111100); //SYNC
+      _spi->transfer(SYNC); //SYNC command
       delayMicroseconds(4); //t11 delay 24*tau = 3.125 us //delay should be larger, so we delay by 4 us
-      _spi->transfer(0b11111111); //WAKEUP
+      _spi->transfer(WAKEUP); //WAKEUP command
 
       //Step 3.
-      _spi->transfer(0b00000001); //Issue RDATA (0000 0001) command
+      _spi->transfer(RDATA); //Issue RDATA command
       delayMicroseconds(7); //Wait t6 time (~6.51 us) REF: P34, FIG:30.
 
 	  _outputBuffer[0] = _spi->transfer(0); // MSB 


### PR DESCRIPTION
- Replace 0b00000001 with RDATA constant
- Replace 0b00000011 with RDATAC constant
- Replace 0b00001111 with SDATAC constant
- Replace 0b11111100 with SYNC constant
- Replace 0b11111111 with WAKEUP constant

Using defined constants improves readability and maintainability. If datasheet values change or there was a typo, fix is in one place.